### PR TITLE
Add fragment block test specs and fixtures

### DIFF
--- a/drafts/fixtures/fragment/basic.plain.html
+++ b/drafts/fixtures/fragment/basic.plain.html
@@ -1,0 +1,10 @@
+<div>
+  <h1>Fragment Block Test Page</h1>
+</div>
+<div>
+  <div class="fragment">
+    <div>
+      <div>/drafts/fixtures/fragment/fragment-content</div>
+    </div>
+  </div>
+</div>

--- a/drafts/fixtures/fragment/fragment-content.plain.html
+++ b/drafts/fixtures/fragment/fragment-content.plain.html
@@ -1,0 +1,5 @@
+<div>
+  <h2>Fragment Heading</h2>
+  <p>This is content loaded from a fragment. It demonstrates that the fragment block can fetch and render external content.</p>
+  <p><a href="/blog/">Read more on the blog</a></p>
+</div>

--- a/specs/fragment/basic.md
+++ b/specs/fragment/basic.md
@@ -1,0 +1,36 @@
+---
+block: fragment
+fixture: /drafts/fixtures/fragment/basic.plain.html
+tags: [content, responsive]
+---
+
+## Tracer bullet
+
+- The block loads and decorates without console errors
+- The fragment content from the referenced path replaces the block markup
+
+## Fragment content rendering
+
+- The heading from the fragment content is visible on the page
+- The paragraph text from the fragment content is visible on the page
+- Links authored in the fragment content are rendered and functional
+
+## Section integration
+
+- The fragment content is rendered within a decorated section (has the `section` class)
+- The parent section gains the `fragment-container` class after decoration
+- The fragment content sections are nested inside the fragment wrapper
+
+## CSS behavior
+
+- Nested sections inside the fragment wrapper have no extra left/right padding
+- The first nested section has no extra top padding
+- The last nested section has no extra bottom padding
+
+## Accessibility
+
+- The fragment content is accessible in the accessibility tree with its heading and link text
+
+## Responsive layout
+
+- On mobile (375px), the fragment content renders correctly with no overflow


### PR DESCRIPTION
## Description
Added comprehensive test specifications and fixtures for the fragment block component, including:

- **Test specification** (`specs/fragment/basic.md`): Documents expected behavior across tracer bullet, content rendering, section integration, CSS behavior, accessibility, and responsive layout
- **Test fixtures**: 
  - `drafts/fixtures/fragment/basic.plain.html`: Main test page with fragment block
  - `drafts/fixtures/fragment/fragment-content.plain.html`: External content to be loaded by the fragment block

These fixtures enable testing of the fragment block's ability to load and render external content while maintaining proper section structure, styling, and accessibility.

## Test URLs
- Before: https://main--shsteimer-com--shsteimer.aem.live/blog/
- After: https://claude-test-fragment-block-baseline-5BGJi--shsteimer-com--shsteimer.aem.live/blog/

## Testing
Fixtures are ready for manual testing and automated test execution against the fragment block implementation.

https://claude.ai/code/session_01Vsa1pBfUsD6gxm3JK1hrnA